### PR TITLE
Update Data.php

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -404,7 +404,7 @@ class Data extends AbstractHelper
             if($type == $map['hub_type'])
             {
                 $value = $this->_getCustomerAttributeValue($map['magento_attribute'], $customer);
-                if($value)
+                if(strlen($value) > 0)
                 {
                     $extraProperties[$map['hub_attribute']] = $value;
                 }


### PR DESCRIPTION
_getCustomerAttributeValue always returns a string, so if the return value of this function is 0 you never enter the body of the if.
Example:
the custom attribute on Magento is of type bool, the attribute correctly assumes the value 0. Result: it is not possible to export the custom attribute.