### PR TITLE
Avoid undefined index 'remote_ip' on programmatically order.

### DIFF
--- a/Model/Event/Strategy/OrderCompleted.php
+++ b/Model/Event/Strategy/OrderCompleted.php
@@ -34,7 +34,9 @@ class OrderCompleted extends EventStrategy
             if(array_key_exists('updated_at', $context)) {
                 $data['created_at'] = $context['updated_at'];
             }
-            $data['env_remote_ip'] = $context['remote_ip'];
+            if (isset($context['remote_ip'])){
+                $data['env_remote_ip'] = $context['remote_ip'];
+            }
             $eventData = array(
                 'type' => 'sale',
                 'increment_id' => $context['increment_id']


### PR DESCRIPTION
When an order is created programmatically (eg via cron area) you get Notice: Undefined index: remote_ip in .../vendor/contactlab/magento2-hub/Model/Event/Strategy/OrderCompleted.php
In general, the IP address is not always available.